### PR TITLE
Implement basic config options

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,6 @@ RSpec/MultipleExpectations:
 
 RSpec/MultipleMemoizedHelpers:
   Max: 10
+
+RSpec/NestedGroups:
+  Max: 4

--- a/lib/request_logger.rb
+++ b/lib/request_logger.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'request_logger/config'
 require_relative 'request_logger/version'
 require_relative 'request_logger/patches/net/http'
 
@@ -8,7 +9,17 @@ module RequestLogger
   class Error < StandardError; end
 
   class << self
+    def config
+      @config ||= RequestLogger::Config.new
+    end
+
+    def configure
+      yield(config)
+    end
+
     def log_connection(host, port)
+      return unless config.log_connection
+
       send_log("Connected to #{host}:#{port}")
     end
 
@@ -20,12 +31,16 @@ module RequestLogger
     private
 
     def log_request(request)
+      return unless config.log_request
+
       log_path(request[:method], request[:path])
       log_headers(request[:headers])
       log_body(request[:body])
     end
 
     def log_response(response)
+      return unless config.log_response
+
       log_status_code(response[:code])
       log_headers(response[:headers])
       log_body(response[:body])
@@ -36,6 +51,8 @@ module RequestLogger
     end
 
     def log_headers(headers)
+      return unless config.log_headers
+
       send_log("Headers: #{headers.inspect}")
     end
 

--- a/lib/request_logger/config.rb
+++ b/lib/request_logger/config.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module RequestLogger
+  # Config class for RequestLogger
+  # This class holds configuration options for logging HTTP requests and responses.
+  #
+  # @example
+  #   RequestLogger.configure do |config|
+  #     config.log_connection = true
+  #     config.log_request = false
+  #     config.log_response = false
+  #     config.log_headers = true
+  #   end
+  class Config
+    attr_accessor :log_connection, :log_request, :log_response, :log_headers
+
+    def initialize
+      @log_connection = false
+      @log_request = true
+      @log_response = true
+      @log_headers = false
+    end
+  end
+end

--- a/spec/request_logger_spec.rb
+++ b/spec/request_logger_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe RequestLogger do
   end
 
   describe '.log_connection' do
+    before do
+      described_class.configure do |config|
+        config.log_connection = true
+      end
+    end
+
     it 'logs connection details' do
       expect { described_class.log_connection(path, port) }
         .to output("[Request] Connected to #{path}:#{port}\n").to_stdout
@@ -52,13 +58,53 @@ RSpec.describe RequestLogger do
       end.to output(
         [
           expected_output[:path],
-          expected_output[:headers],
           expected_output[:body],
           expected_output[:status],
-          expected_output[:response_headers],
           expected_output[:response_body]
         ].join("\n").concat("\n")
       ).to_stdout
+    end
+
+    context 'when logging is configured' do
+      context 'when configs are all true' do
+        before do
+          described_class.configure do |config|
+            config.log_request = true
+            config.log_response = true
+            config.log_headers = true
+          end
+        end
+
+        it 'logs everything' do
+          expect do
+            described_class.log(params)
+          end.to output(
+            [
+              expected_output[:path],
+              expected_output[:headers],
+              expected_output[:body],
+              expected_output[:status],
+              expected_output[:response_headers],
+              expected_output[:response_body]
+            ].join("\n").concat("\n")
+          ).to_stdout
+        end
+      end
+
+      context 'when configs are all false' do
+        before do
+          described_class.configure do |config|
+            config.log_connection = false
+            config.log_request = false
+            config.log_response = false
+            config.log_headers = false
+          end
+        end
+
+        it 'does not log anything' do
+          expect { described_class.log(params) }.not_to output.to_stdout
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Implement basic config options to choose whether to log headers, request, response and connections.